### PR TITLE
Make path lines look a bit nicer

### DIFF
--- a/src/map/pathguided.rs
+++ b/src/map/pathguided.rs
@@ -5,19 +5,28 @@ use std::collections::VecDeque;
 #[derive(Component, Default, Debug)]
 pub struct PathGuided {
     pub path: VecDeque<HexCoord>,
+    current: Option<HexCoord>,
 }
 
 impl PathGuided {
     pub fn path(&mut self, path: Vec<HexCoord>) {
         self.path = VecDeque::from(path);
-        self.path.pop_front();
+        self.current = self.path.pop_front();
     }
 
     pub fn advance(&mut self) {
-        self.path.pop_front();
+        self.current = self.path.pop_front();
     }
 
     pub fn next(&self) -> Option<&HexCoord> {
         self.path.front()
+    }
+
+    pub fn last(&self) -> Option<&HexCoord> {
+        self.path.back()
+    }
+
+    pub fn current(&self) -> Option<HexCoord> {
+        self.current
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -53,7 +53,7 @@ pub fn update_path_mesh(path: Path, mesh: &mut Mesh) {
     let indextmpl = vec![0, 1, 3, 0, 3, 2];
     let indices = Indices::U32(
         (0..path.steps)
-            .map(|idx| (idx * 2) as u32)
+            .map(|idx| idx * 2)
             .flat_map(|a| indextmpl.iter().map(move |b| a + b))
             .collect(),
     );


### PR DESCRIPTION
Change the spline keys to be the edges between hexes with the interpolation point being the center of the next hex.

Also fix #18 by tracking current position in path separate from the position of the presence that gets update through a command.