### PR TITLE
expl_hexgrid: Optionally derive bevy's Reflect trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2219,6 +2219,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 name = "expl_hexgrid"
 version = "0.1.0"
 dependencies = [
+ "bevy_reflect",
  "disjoint-hash-set",
  "glam",
  "itertools 0.11.0",

--- a/crates/expl_hexgrid/Cargo.toml
+++ b/crates/expl_hexgrid/Cargo.toml
@@ -7,8 +7,12 @@ license = "ISC"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bevy_reflect = { version = "0.11", optional = true }
 disjoint-hash-set = "1.0.0"
 glam = ">=0.22, <0.25"
-itertools = "0.11.0"
-serde_with = "3.0.0"
-thiserror = "1.0.48"
+itertools = "0.11"
+serde_with = "3.0"
+thiserror = "1.0"
+
+[features]
+bevy-reflect = ["dep:bevy_reflect"]

--- a/crates/expl_hexgrid/src/coord.rs
+++ b/crates/expl_hexgrid/src/coord.rs
@@ -7,6 +7,9 @@ use std::{
 };
 use thiserror::Error;
 
+#[cfg(feature = "bevy-reflect")]
+use bevy_reflect::Reflect;
+
 // sqrt(3)
 const SQRT3: f32 = 1.732_050_8;
 
@@ -25,6 +28,7 @@ const SQRT3: f32 = 1.732_050_8;
     SerializeDisplay,
     DeserializeFromStr,
 )]
+#[cfg_attr(feature = "bevy-reflect", derive(Reflect))]
 pub struct HexCoord {
     pub q: i32,
     pub r: i32,

--- a/crates/expl_hexgrid/src/layout.rs
+++ b/crates/expl_hexgrid/src/layout.rs
@@ -1,5 +1,8 @@
 use super::{HexCoord, Transform};
 
+#[cfg(feature = "bevy-reflect")]
+use bevy_reflect::Reflect;
+
 pub trait GridLayout: Copy + Clone + PartialEq {
     type LayoutIter<'a>: Iterator<Item = HexCoord> + ExactSizeIterator
     where
@@ -13,7 +16,8 @@ pub trait GridLayout: Copy + Clone + PartialEq {
     fn center(&self) -> HexCoord;
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "bevy-reflect", derive(Reflect))]
 pub struct SquareGridLayout {
     pub width: i32,
     pub height: i32,
@@ -84,7 +88,8 @@ impl<'a> Iterator for SquareGridLayoutIterator<'a> {
 
 impl ExactSizeIterator for SquareGridLayoutIterator<'_> {}
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "bevy-reflect", derive(Reflect))]
 pub struct HexagonalGridLayout {
     pub radius: i32,
 }


### PR DESCRIPTION
Also relax version constraints of all dependencies.