### PR TITLE
Use latest stable rust in GitHub actions again

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Rust toolchain
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.73.0
+        toolchain: stable
         components: clippy
     - uses: rui314/setup-mold@v1
     - name: Install dependencies


### PR DESCRIPTION
This reverts commit 7d82ac4824fe96f4292048864b8c8e08d3560fc7.